### PR TITLE
Rename spawnable names to be PascalCase and not have 'create'

### DIFF
--- a/src/entities/spawnable/index.ts
+++ b/src/entities/spawnable/index.ts
@@ -7,10 +7,10 @@ import { createSolid } from './solid.js'
 import type { Game } from '~/game.js'
 
 export const registerDefaultSpawnables = (game: Game<boolean>) => {
-  game.register('createBouncyBall', createBouncyBall)
-  game.register('createComplexSolid', createComplexSolid)
-  game.register('createMarker', createMarker)
-  game.register('createNonsolid', createNonsolid)
-  game.register('createSimpleNPC', createSimpleNPC)
-  game.register('createSolid', createSolid)
+  game.register('BouncyBall', createBouncyBall)
+  game.register('ComplexSolid', createComplexSolid)
+  game.register('Marker', createMarker)
+  game.register('Nonsolid', createNonsolid)
+  game.register('SimpleNPC', createSimpleNPC)
+  game.register('Solid', createSolid)
 }


### PR DESCRIPTION
How do we feel about this? Would require us to hunt down a few `entityFn: 'createX'` declarations elsewhere (i.e. in `dreamlab-worlds`, `dreamlab-app`, and `dreamlab-mp`)