### PR TITLE
Tracing via @char-lt/brakepad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dreamlab.gg/core",
       "version": "0.0.82",
       "dependencies": {
-        "@char-lt/brakepad": "^1.0.0",
+        "@char-lt/brakepad": "^1.1.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@pixi/particle-emitter": "^5.0.8",
         "buffer": "^6.0.3",
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@char-lt/brakepad": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@char-lt/brakepad/-/brakepad-1.0.0.tgz",
-      "integrity": "sha512-0TU+1N5eKYGchhcEd84Id0/i7h+flACl+2tQxCfaaOJ+IXcoPymxYne3KrBm3AkkMJ2Z8g+tlkZPNIIpreW/Kg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@char-lt/brakepad/-/brakepad-1.1.0.tgz",
+      "integrity": "sha512-Ogxnf8ra+T5BdxcmNgkUh8Pk/ozhog94VCISVWT7gr9EYbw5rTvK9nBXZgZPmRiJFAk3bWYY1gpxGQpPou0q6g==",
       "dependencies": {
         "@deno/shim-crypto": "~0.3.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@dreamlab.gg/core",
       "version": "0.0.82",
       "dependencies": {
+        "@char-lt/brakepad": "^1.0.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@pixi/particle-emitter": "^5.0.8",
         "buffer": "^6.0.3",
@@ -456,6 +457,19 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@char-lt/brakepad": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@char-lt/brakepad/-/brakepad-1.0.0.tgz",
+      "integrity": "sha512-0TU+1N5eKYGchhcEd84Id0/i7h+flACl+2tQxCfaaOJ+IXcoPymxYne3KrBm3AkkMJ2Z8g+tlkZPNIIpreW/Kg==",
+      "dependencies": {
+        "@deno/shim-crypto": "~0.3.1"
+      }
+    },
+    "node_modules/@deno/shim-crypto": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@deno/shim-crypto/-/shim-crypto-0.3.1.tgz",
+      "integrity": "sha512-ed4pNnfur6UbASEgF34gVxR9p7Mc3qF+Ygbmjiil8ws5IhNFhPDFy5vE5hQAUA9JmVsSxXPcVLM5Rf8LOZqQ5Q=="
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.41.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@char-lt/brakepad": "^1.0.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@pixi/particle-emitter": "^5.0.8",
     "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@char-lt/brakepad": "^1.0.0",
+    "@char-lt/brakepad": "^1.1.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@pixi/particle-emitter": "^5.0.8",
     "buffer": "^6.0.3",

--- a/src/game.ts
+++ b/src/game.ts
@@ -448,8 +448,8 @@ export async function createGame<Server extends boolean>(
       return
     }
 
+    tracing.enter('physics')
     while (physicsTickAcc >= physicsTickDelta) {
-      tracing.enter('physics')
       physicsTickAcc -= physicsTickDelta
 
       tracing.enter('matter update')
@@ -480,6 +480,8 @@ export async function createGame<Server extends boolean>(
 
       tracing.exit()
     }
+
+    tracing.exit()
 
     if (renderContext) {
       tracing.enter('render')

--- a/src/game.ts
+++ b/src/game.ts
@@ -430,7 +430,7 @@ export async function createGame<Server extends boolean>(
 
   // #region Tick Loop
   const onTick = async () => {
-    tracing.enter('tick')
+    tracing.enter('core_tick')
 
     const now = performance.now()
     const delta = now - time
@@ -448,21 +448,21 @@ export async function createGame<Server extends boolean>(
       return
     }
 
-    tracing.enter('physics')
     while (physicsTickAcc >= physicsTickDelta) {
+      tracing.enter('physics')
       physicsTickAcc -= physicsTickDelta
 
-      tracing.enter('matter update')
+      tracing.enter('matter_update')
       Matter.Engine.update(physics.engine, physicsTickDelta)
 
-      tracing.replace('global event')
+      tracing.replace('step_event')
       const timeState = {
         delta: physicsTickDelta / 1_000,
         time: time / 1_000,
       }
       events.common.emit('onPhysicsStep', timeState)
 
-      tracing.replace('entities', { count: entities.length })
+      tracing.replace('step_entities', { count: entities.length })
       for (const entity of entities) {
         if (typeof entity.onPhysicsStep !== 'function') continue
 
@@ -479,9 +479,8 @@ export async function createGame<Server extends boolean>(
       }
 
       tracing.exit()
+      tracing.exit()
     }
-
-    tracing.exit()
 
     if (renderContext) {
       tracing.enter('render')


### PR DESCRIPTION
We can profile the tick loop and allow user scripts to trace anything they want and get the results on both the client and server. Batched trace streaming has landed in `dreamlab-mp-server` already and we can leave `dreamlab-game` with the nop tracer for now